### PR TITLE
do not uppercase columns

### DIFF
--- a/.github/scripts/statsig_sync.py
+++ b/.github/scripts/statsig_sync.py
@@ -107,16 +107,6 @@ def sync_file(file_path):
 
     # Additional processing for metric sources
     if 'metric_sources' in file_path:
-        # Uppercase timestampColumn if present
-        if 'timestampColumn' in content:
-            content['timestampColumn'] = content['timestampColumn'].upper()
-        
-        # Uppercase columns in idTypeMapping if present
-        if 'idTypeMapping' in content and isinstance(content['idTypeMapping'], list):
-            for mapping in content['idTypeMapping']:
-                if 'column' in mapping:
-                    mapping['column'] = mapping['column'].upper()
-
         create_or_update_metric_source(content)
     # Processing for metrics
     elif 'metrics' in file_path:


### PR DESCRIPTION
When the timestampColumn or idTypeMapping columns are converted to uppercase, Statsig server-side validation will fail to identify the columns <img width="601" height="351" alt="Screenshot 2025-07-11 at 9 47 08 AM" src="https://github.com/user-attachments/assets/f9f4c73c-9b08-4199-b5e6-f0b623205dfd" />
